### PR TITLE
Add Profile abstraction instead NSManagedObject

### DIFF
--- a/CoreDataProfiles/Sources/Scenes/Model/DataProvider.swift
+++ b/CoreDataProfiles/Sources/Scenes/Model/DataProvider.swift
@@ -14,20 +14,13 @@ class DataProvider: DataProviderProtocol {
     // MARK: - Properties
     
     var profiles: [NSManagedObject]?
-    var profile: NSManagedObject?
     
     private let appDelegate = UIApplication.shared.delegate as? AppDelegate
     private lazy var managedContext = appDelegate?.persistentContainer.viewContext
     
-    // MARK: - Show Profiles
-    func felchProfilesList() {
-        let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: "Profile")
-        
-        do {
-            profiles = try managedContext?.fetch(fetchRequest)
-        } catch let error as NSError {
-            print("Could not fetch. \(error), \(error.userInfo)")
-        }
+    // MARK: - Felch profiles from NSManagedObject to Profile
+    func felchProfiles() -> [Profile]? {
+        try? managedContext?.fetch(Profile.fetchRequest())
     }
     
     // MARK: - Add Profile

--- a/CoreDataProfiles/Sources/Scenes/Model/Protocols/DataProviderProtocol.swift
+++ b/CoreDataProfiles/Sources/Scenes/Model/Protocols/DataProviderProtocol.swift
@@ -10,9 +10,8 @@ import CoreData
 
 protocol DataProviderProtocol {
     var profiles: [NSManagedObject]? { get set }
-    var profile: NSManagedObject? { get set }
     
-    func felchProfilesList()
+    func felchProfiles() -> [Profile]?
     func addProfile(name: String, completion: @escaping () -> ())
     func deleteProfile(profile: NSManagedObject, index: Int, completion: @escaping () -> ())
     func updateProfile(profile: NSManagedObject, completion: @escaping () -> ())

--- a/CoreDataProfiles/Sources/Scenes/Presenters/ProfilePresenter.swift
+++ b/CoreDataProfiles/Sources/Scenes/Presenters/ProfilePresenter.swift
@@ -6,14 +6,13 @@
 //
 
 import Foundation
-import CoreData
 
 class ProfilePresenter: ProfilePresenterProtocol {
     
     // MARK: - Properties
     
     weak var delegate: ProfilePresenterDelegate?
-    var profile: NSManagedObject?
+    var profile: Profile?
     var dataProvider = DataProvider()
     
     // MARK: - Configuration

--- a/CoreDataProfiles/Sources/Scenes/Presenters/Protocols/ProfilePresenterProtocol.swift
+++ b/CoreDataProfiles/Sources/Scenes/Presenters/Protocols/ProfilePresenterProtocol.swift
@@ -6,11 +6,10 @@
 //
 
 import Foundation
-import CoreData
 
 protocol ProfilePresenterProtocol {
     var delegate: ProfilePresenterDelegate? { get set }
-    var profile: NSManagedObject? { get }
+    var profile: Profile? { get }
     var dataProvider: DataProvider { get set }
     
     func setViewDelegate(delegate: ProfilePresenterDelegate)

--- a/CoreDataProfiles/Sources/Scenes/Presenters/Protocols/RootPresenterProtocol.swift
+++ b/CoreDataProfiles/Sources/Scenes/Presenters/Protocols/RootPresenterProtocol.swift
@@ -6,15 +6,14 @@
 //
 
 import Foundation
-import CoreData
 
 protocol RootPresenterProtocol {
     var delegate: RootPresenterDelegate? { get set }
-    var profiles: [NSManagedObject] { get }
+    var profiles: [Profile] { get }
     var dataProvider: DataProvider { get set }
     
     func setViewDelegate(delegate: RootPresenterDelegate)
-    func setupProfiles()
+    func updateProfiles()
     
     func addProfile(name: String)
     func deleteProfile(index: Int, completion: @escaping () -> ())

--- a/CoreDataProfiles/Sources/Scenes/Presenters/RootPresenter.swift
+++ b/CoreDataProfiles/Sources/Scenes/Presenters/RootPresenter.swift
@@ -6,14 +6,13 @@
 //
 
 import Foundation
-import CoreData
 
 class RootPresenter: RootPresenterProtocol {
     
     // MARK: - Properties
     
     weak var delegate: RootPresenterDelegate?
-    var profiles: [NSManagedObject] = []
+    var profiles: [Profile] = []
     var dataProvider = DataProvider()
     
     // MARK: - Configuration
@@ -22,10 +21,8 @@ class RootPresenter: RootPresenterProtocol {
         self.delegate = delegate
     }
     
-    func setupProfiles() {
-        dataProvider.felchProfilesList()
-        
-        guard let profiles = dataProvider.profiles else { return }
+    func updateProfiles() {
+        guard let profiles = dataProvider.felchProfiles() else { return }
         self.profiles = profiles
     }
     
@@ -33,7 +30,7 @@ class RootPresenter: RootPresenterProtocol {
     
     func addProfile(name: String) {
         dataProvider.addProfile(name: name) {
-            self.updateProfilesList()
+            self.updateProfiles()
             self.delegate?.reloadData()
         }
     }
@@ -41,14 +38,8 @@ class RootPresenter: RootPresenterProtocol {
     func deleteProfile(index: Int, completion: @escaping () -> ()) {
         guard let profile = dataProvider.profiles?[index] else { return }
         dataProvider.deleteProfile(profile: profile, index: index) {
-            self.updateProfilesList()
+            self.updateProfiles()
             completion()
         }
-    }
-    
-    // MARK: - Private functions
-    private func updateProfilesList() {
-        guard let profiles = dataProvider.profiles else { return }
-        self.profiles = profiles
     }
 }

--- a/CoreDataProfiles/Sources/Scenes/Views/ProfileViewController.swift
+++ b/CoreDataProfiles/Sources/Scenes/Views/ProfileViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 
 // MARK: - View
 class ProfileViewController: UIViewController {

--- a/CoreDataProfiles/Sources/Scenes/Views/Protocols/ProfilePresenterDelegate.swift
+++ b/CoreDataProfiles/Sources/Scenes/Views/Protocols/ProfilePresenterDelegate.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol ProfilePresenterDelegate: AnyObject {
-    
+    // TODO
 }

--- a/CoreDataProfiles/Sources/Scenes/Views/RootViewController.swift
+++ b/CoreDataProfiles/Sources/Scenes/Views/RootViewController.swift
@@ -42,7 +42,7 @@ class RootViewController: UIViewController {
         
         // MARK: Presenter setup
         presenter.setViewDelegate(delegate: self)
-        presenter.setupProfiles()
+        presenter.updateProfiles()
         
         // MARK: Navigaiton Setup
         setupNavigation()


### PR DESCRIPTION
Теперь `DataProvider` отдает наружу не объект типа `NSManagedObject`, а объект типа `Profile`. Сделал это, чтобы избежать использования объекта `NSManagedObjetct` везде, кроме самого провайдера. Он по прежнему оперирует и у вправляет именно им.